### PR TITLE
Update harfbuzz versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,8 @@ readme = "README.md"
 categories = ["graphics", "text-processing"]
 
 [dependencies]
-# Note: this should be updated to 0.3.2 when it's released.
-harfbuzz = "=0.3.0"
-harfbuzz-sys = "=0.3.0"
+harfbuzz = "0.3.1"
+harfbuzz-sys = "0.3.2"
 euclid = "0.19"
 font-kit = { version = "0.1.0"} #, features = ["loader-freetype-default"] }
 unicode-normalization = "0.1.8"


### PR DESCRIPTION
This updates harfbuzz to 0.3.1 (which gets us blobs from atomically refcounted byte vectors) and harfbuzz-sys 0.3.2, which fixes a compile error.

Fixes #7