### PR TITLE
Set a Devanagari font on Linux, too.

### DIFF
--- a/examples/render.rs
+++ b/examples/render.rs
@@ -18,6 +18,8 @@ use skribo::{
 const DEVANAGARI_FONT_POSTSCRIPT_NAME: &str = "NirmalaUI";
 #[cfg(target_os = "macos")]
 const DEVANAGARI_FONT_POSTSCRIPT_NAME: &str = "DevanagariUI";
+#[cfg(target_os = "linux")]
+const DEVANAGARI_FONT_POSTSCRIPT_NAME: &str = "NotoSerifDevanagari";
 
 struct SimpleSurface {
     width: usize,
@@ -131,7 +133,7 @@ fn make_collection() -> FontCollection {
 
     let font = source
         .select_by_postscript_name(DEVANAGARI_FONT_POSTSCRIPT_NAME)
-        .unwrap()
+        .expect("failed to select Devanagari font")
         .load()
         .unwrap();
     collection.add_family(FontFamily::new_from_font(font));


### PR DESCRIPTION
This makes `examples/render.rs` compile on linux, by choosing a default font. I don't know that there's a *good* default choice, so I just picked one arbitrarily. I'd be happy to change it.

There seems to be a `font-kit` bug that prevents correct rendering on my system, even with this patch: only the "H" and "हि" render correctly. Updating font-kit to the latest github version fixes this.