### PR TITLE
Update `font-kit` to 0.2 for wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ categories = ["graphics", "text-processing"]
 harfbuzz = "0.3.1"
 harfbuzz-sys = "0.3.2"
 euclid = "0.19"
-font-kit = { version = "0.1.0"} #, features = ["loader-freetype-default"] }
+font-kit = { version = "0.2.0"} #, features = ["loader-freetype-default"] }
 unicode-normalization = "0.1.8"
 log = "0.4"


### PR DESCRIPTION
Also fixes several bugs in upstream `font-kit`.