### PR TITLE
Bump euclid and font-kit to 0.2 and 0.4 respectively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["graphics", "text-processing"]
 [dependencies]
 harfbuzz = "0.3.1"
 harfbuzz-sys = "0.3.2"
-euclid = "0.19"
-font-kit = { version = "0.2.0"} #, features = ["loader-freetype-default"] }
+euclid = "0.20"
+font-kit = { version = "0.4.0"} #, features = ["loader-freetype-default"] }
 unicode-normalization = "0.1.8"
 log = "0.4"

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -10,6 +10,7 @@ use font_kit::canvas::{Canvas, Format, RasterizationOptions};
 use font_kit::family_name::FamilyName;
 use font_kit::hinting::HintingOptions;
 use font_kit::properties::Properties;
+use font_kit::loader::FontTransform;
 use font_kit::source::SystemSource;
 
 use skribo::{
@@ -83,6 +84,7 @@ impl SimpleSurface {
                 .raster_bounds(
                     glyph_id,
                     layout.size,
+                    &FontTransform::identity(),
                     &Point2D::zero(),
                     HintingOptions::None,
                     RasterizationOptions::GrayscaleAa,
@@ -109,6 +111,7 @@ impl SimpleSurface {
                         glyph_id,
                         // TODO(font-kit): this is missing anamorphic and skew features
                         layout.size,
+                        &FontTransform::identity(),
                         &neg_origin,
                         HintingOptions::None,
                         RasterizationOptions::GrayscaleAa,
@@ -143,6 +146,7 @@ impl SimpleSurface {
                     .raster_bounds(
                         glyph_id,
                         size,
+                        &FontTransform::identity(),
                         &Point2D::zero(),
                         HintingOptions::None,
                         RasterizationOptions::GrayscaleAa,
@@ -167,6 +171,7 @@ impl SimpleSurface {
                             glyph_id,
                             // TODO(font-kit): this is missing anamorphic and skew features
                             size,
+                            &FontTransform::identity(),
                             &neg_origin,
                             HintingOptions::None,
                             RasterizationOptions::GrayscaleAa,
@@ -226,6 +231,7 @@ fn main() {
         font.raster_bounds(
             glyph_id,
             32.0,
+            &FontTransform::identity(),
             &Point2D::zero(),
             HintingOptions::None,
             RasterizationOptions::GrayscaleAa
@@ -237,6 +243,7 @@ fn main() {
         glyph_id,
         // TODO(font-kit): this is missing anamorphic and skew features
         style.size,
+        &FontTransform::identity(),
         &Point2D::zero(),
         HintingOptions::None,
         RasterizationOptions::GrayscaleAa,
@@ -247,6 +254,7 @@ fn main() {
         &mut canvas,
         glyph_id,
         style.size,
+        &FontTransform::identity(),
         &Point2D::new(16.0, 16.0),
         HintingOptions::None,
         RasterizationOptions::GrayscaleAa,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate log;
 
-use euclid::Vector2D;
+use euclid::default::Vector2D;
 use font_kit::loaders::default::Font;
 
 mod collection;

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 
 use harfbuzz::sys::{hb_script_t, HB_SCRIPT_COMMON, HB_SCRIPT_INHERITED, HB_SCRIPT_UNKNOWN};
 
-use euclid::Vector2D;
+use euclid::default::Vector2D;
 
 use crate::hb_layout::{layout_fragment, HbFace};
 use crate::unicode_funcs::lookup_script;


### PR DESCRIPTION
Hi, this is part of my effort on updating pathfinder's font-kit and euclid to fix a crash. This updates both font-kit and euclid to their newer versions, but they come with some breaking changes so this adjusts imports and a bunch of other things accordingly.