### PR TITLE
Fix issue where glyphs were renderered as outlines

### DIFF
--- a/src/hb_layout.rs
+++ b/src/hb_layout.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 
 use harfbuzz::sys::{
-    hb_buffer_get_glyph_infos,
+    hb_buffer_get_glyph_infos, hb_ot_font_set_funcs,
     hb_buffer_get_glyph_positions, hb_face_create, hb_face_destroy, hb_face_reference, hb_face_t,
     hb_font_create, hb_font_destroy, hb_position_t, hb_shape,
 };
@@ -88,6 +88,7 @@ pub fn layout_run(style: &TextStyle, font: &FontRef, text: &str) -> Layout {
         let hb_face = hb_thread_data.create_hb_face_for_font(font);
         unsafe {
             let hb_font = hb_font_create(hb_face.hb_face);
+            hb_ot_font_set_funcs(hb_font);
             hb_shape(hb_font, b.as_ptr(), std::ptr::null(), 0);
             hb_font_destroy(hb_font);
             let mut n_glyph = 0;


### PR DESCRIPTION
Closes #18 

I came across this while trying out the canvas_nanovg example in [pathfinder](https://github.com/servo/pathfinder/tree/master/examples/canvas_nanovg). 

The glyphs were rendered like this

![skribo](https://user-images.githubusercontent.com/182415/87816751-ade00280-c81c-11ea-8f1a-f36d289ef4e9.png)

This is the result after this patch:

![skribo fix](https://user-images.githubusercontent.com/182415/87817118-378fd000-c81d-11ea-8b12-d2e12e52f6a9.png)

Credit goes to @jeroentervoorde and @Stoeoef, who figured this out.

Links:
https://github.com/servo/pathfinder/issues/194
https://github.com/maps4print/azul/issues/125#issuecomment-479172471
