### PR TITLE
Fixed out of bond error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 # some cases, their employer may be the copyright holder.  To see the full list
 # of contributors, see the revision history in source control.
 Raph Levien
+Josué Teodoro Moreira

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -127,7 +127,13 @@ impl<'a> Iterator for Itemizer<'a> {
                 end += c.len_utf8();
             }
             self.ix = end;
-            Some((start..end, &self.collection.families[font_ix].fonts[0]))
+
+            if &self.collection.families.len() >= &1 {
+                Some((start..end, &self.collection.families[font_ix].fonts[0]))
+            }
+            else {
+                None
+            }
         } else {
             None
         }


### PR DESCRIPTION
Basically the function I modified returned the first parameter of a Vector but did not check if it was really created. In my case, neovide couldn't run since skribo was raising an out of bound error.

I suggest adding a warning like "Skribo could not find fonts" or whatever. 

Also, please remove the commit where I added myself to the AUTHORS list. Hadn't read about "substantive commits"