### PR TITLE
Variable shaper

### DIFF
--- a/src/collection.rs
+++ b/src/collection.rs
@@ -118,7 +118,9 @@ pub(crate) struct FontId {
 
 impl FontId {
     pub(crate) fn from_font(font: &FontRef) -> FontId {
-        FontId { postscript_name: font.font.postscript_name().unwrap_or_default() }
+        FontId {
+            postscript_name: font.font.postscript_name().unwrap_or_default(),
+        }
     }
 }
 
@@ -142,8 +144,7 @@ impl<'a> Iterator for Itemizer<'a> {
 
             if &self.collection.families.len() >= &1 {
                 Some((start..end, &self.collection.families[font_ix].fonts[0]))
-            }
-            else {
+            } else {
                 None
             }
         } else {

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,10 +1,11 @@
 //! The font collection type.
 
+use crate::Font;
+use std::collections::HashMap;
+use std::convert::TryInto;
 use std::fmt;
 use std::ops::Range;
 use std::sync::Arc;
-
-use crate::Font;
 
 /// A collection of fonts
 pub struct FontCollection {
@@ -20,6 +21,7 @@ pub struct FontFamily {
 #[derive(Clone)]
 pub struct FontRef {
     pub font: Arc<Font>,
+    pub location: HashMap<[u8; 4], f32>,
 }
 
 impl fmt::Debug for FontRef {
@@ -38,6 +40,16 @@ impl FontRef {
     pub fn new(font: Font) -> FontRef {
         FontRef {
             font: Arc::new(font),
+            location: HashMap::new(),
+        }
+    }
+
+    pub fn set_axis_location(&mut self, tag: &str, location: f32) -> bool {
+        if let Ok(t) = tag.as_bytes().try_into() {
+            self.location.insert(t, location);
+            true
+        } else {
+            false
         }
     }
 }

--- a/src/hb_layout.rs
+++ b/src/hb_layout.rs
@@ -126,18 +126,27 @@ pub fn layout_run(style: &TextStyle, font: &FontRef, text: &str) -> Layout {
     })
 }
 
-pub(crate) fn layout_fragment(
+pub fn layout_fragment(
     style: &TextStyle,
     font: &FontRef,
-    script: hb_script_t,
+    direction: Option<Direction>,
+    script: Option<hb_script_t>,
+    language: Option<String>,
     text: &str,
 ) -> LayoutFragment {
     let mut b = Buffer::new();
     install_unicode_funcs(&mut b);
     b.add_str(text);
-    b.set_direction(Direction::LTR);
-    b.set_script(script);
-    b.set_language(Language::from_string("en_US"));
+    b.guess_segment_properties();
+    if let Some(d) = direction {
+        b.set_direction(d);
+    }
+    if let Some(s) = script {
+        b.set_script(s);
+    }
+    if let Some(lang) = language {
+        b.set_language(Language::from_string(&lang));
+    }
     let hb_face = HbFace::new(font);
     unsafe {
         let hb_font = hb_font_create(hb_face.hb_face);
@@ -178,8 +187,8 @@ pub(crate) fn layout_fragment(
         LayoutFragment {
             //size: style.size,
             substr_len: text.len(),
-            script,
-            glyphs: glyphs,
+            script: b.get_script(),
+            glyphs,
             advance: total_adv,
             font: font.clone(),
         }

--- a/src/hb_layout.rs
+++ b/src/hb_layout.rs
@@ -171,7 +171,10 @@ pub fn layout_fragment(
             let unsafe_to_break = flags & HB_GLYPH_FLAG_UNSAFE_TO_BREAK != 0;
             trace!(
                 "{:?} {:?} {} {}",
-                glyph.codepoint, (pos.x_offset, pos.y_offset), glyph.cluster, unsafe_to_break
+                glyph.codepoint,
+                (pos.x_offset, pos.y_offset),
+                glyph.cluster,
+                unsafe_to_break
             );
             let g = FragmentGlyph {
                 cluster: glyph.cluster,

--- a/src/hb_layout.rs
+++ b/src/hb_layout.rs
@@ -1,19 +1,18 @@
 //! A HarfBuzz shaping back-end.
 
-use pathfinder_geometry::vector::{Vector2F, vec2i};
+use harfbuzz_sys::{hb_font_set_variations, hb_variation_t};
+use pathfinder_geometry::vector::{vec2i, Vector2F};
 use std::cell::RefCell;
 use std::collections::HashMap;
 
 use harfbuzz::sys::{
-    hb_buffer_get_glyph_infos,
-    hb_buffer_get_glyph_positions, hb_face_create, hb_face_destroy, hb_face_reference, hb_face_t,
-    hb_font_create, hb_font_destroy, hb_position_t, hb_shape,
+    hb_buffer_get_glyph_infos, hb_buffer_get_glyph_positions, hb_face_create, hb_face_destroy,
+    hb_face_reference, hb_face_t, hb_font_create, hb_font_destroy, hb_position_t, hb_shape,
+};
+use harfbuzz::sys::{
+    hb_glyph_info_get_glyph_flags, hb_script_t, HB_GLYPH_FLAG_UNSAFE_TO_BREAK, HB_SCRIPT_DEVANAGARI,
 };
 use harfbuzz::{Blob, Buffer, Direction, Language};
-use harfbuzz::sys::{
-    hb_glyph_info_get_glyph_flags, hb_script_t, HB_GLYPH_FLAG_UNSAFE_TO_BREAK,
-    HB_SCRIPT_DEVANAGARI,
-};
 
 use crate::collection::FontId;
 use crate::session::{FragmentGlyph, LayoutFragment};
@@ -31,13 +30,17 @@ struct HbThreadData {
 
 impl HbThreadData {
     fn new() -> HbThreadData {
-        HbThreadData { hb_face_cache: HashMap::new() }
+        HbThreadData {
+            hb_face_cache: HashMap::new(),
+        }
     }
 
     fn create_hb_face_for_font(&mut self, font: &FontRef) -> HbFace {
-        (*self.hb_face_cache.entry(FontId::from_font(font)).or_insert_with(|| {
-            HbFace::new(font)
-        })).clone()
+        (*self
+            .hb_face_cache
+            .entry(FontId::from_font(font))
+            .or_insert_with(|| HbFace::new(font)))
+        .clone()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ mod tables;
 mod unicode_funcs;
 
 pub use crate::collection::{FontCollection, FontFamily, FontRef};
-pub use crate::hb_layout::layout_run;
-pub use crate::session::LayoutSession;
+pub use crate::hb_layout::{layout_fragment, layout_run};
+pub use crate::session::{LayoutFragment, LayoutSession};
 
 #[derive(Clone)]
 pub struct TextStyle {

--- a/src/session.rs
+++ b/src/session.rs
@@ -21,18 +21,18 @@ pub struct LayoutSession<S: AsRef<str>> {
 
 pub struct LayoutFragment {
     // Length of substring covered by this fragment.
-    pub(crate) substr_len: usize,
-    pub(crate) script: hb_script_t,
-    pub(crate) advance: Vector2F,
-    pub(crate) glyphs: Vec<FragmentGlyph>,
-    pub(crate) font: FontRef,
+    pub substr_len: usize,
+    pub script: hb_script_t,
+    pub advance: Vector2F,
+    pub glyphs: Vec<FragmentGlyph>,
+    pub font: FontRef,
 }
 
 // This should probably be renamed "glyph".
 //
 // Discussion topic: this is so similar to hb_glyph_info_t, maybe we
 // should just use that.
-pub(crate) struct FragmentGlyph {
+pub struct FragmentGlyph {
     pub cluster: u32,
     pub glyph_id: u32,
     pub offset: Vector2F,

--- a/src/session.rs
+++ b/src/session.rs
@@ -71,7 +71,8 @@ impl<S: AsRef<str>> LayoutSession<S> {
             let (script, script_len) = get_script_run(&text.as_ref()[i..]);
             let script_substr = &text.as_ref()[i..i + script_len];
             for (range, font) in collection.itemize(script_substr) {
-                let fragment = layout_fragment(style, font, script, &script_substr[range]);
+                let fragment =
+                    layout_fragment(style, font, None, Some(script), None, &script_substr[range]);
                 fragments.push(fragment);
             }
             i += script_len;
@@ -127,7 +128,8 @@ impl<S: AsRef<str>> LayoutSession<S> {
             let font = &fragment.font;
             let script = fragment.script;
             // TODO: we should pass in the hb_face too, just for performance.
-            let substr_fragment = layout_fragment(&self.style, font, script, substr);
+            let substr_fragment =
+                layout_fragment(&self.style, font, None, Some(script), None, substr);
             self.substr_fragments.push(substr_fragment);
             str_offset += fragment_len;
             fragment_ix += 1;

--- a/src/session.rs
+++ b/src/session.rs
@@ -19,7 +19,7 @@ pub struct LayoutSession<S: AsRef<str>> {
     substr_fragments: Vec<LayoutFragment>,
 }
 
-pub(crate) struct LayoutFragment {
+pub struct LayoutFragment {
     // Length of substring covered by this fragment.
     pub(crate) substr_len: usize,
     pub(crate) script: hb_script_t,

--- a/src/session.rs
+++ b/src/session.rs
@@ -64,11 +64,7 @@ pub struct GlyphInfo {
 }
 
 impl<S: AsRef<str>> LayoutSession<S> {
-    pub fn create(
-        text: S,
-        style: &TextStyle,
-        collection: &FontCollection,
-    ) -> LayoutSession<S> {
+    pub fn create(text: S, style: &TextStyle, collection: &FontCollection) -> LayoutSession<S> {
         let mut i = 0;
         let mut fragments = Vec::new();
         while i < text.as_ref().len() {


### PR DESCRIPTION
So a lot of the changes here are just rustfmt doing its thing, but this PR also:

* Adds a `location` field to the FontRef struct, to allow for shaping variable fonts.
* Passes that location to Harfbuzz when glyphs are being shaped.
* Makes the direction/script/language optional in `layout_fragment`, allowing the user to set explicit values if they want them but using Harfbuzz's `guess_segment_properties` for a decent default fallback.
* Publicizes various structs so that they can be used directly by higher-level layout engines.