### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/hb_layout.rs
+++ b/src/hb_layout.rs
@@ -49,10 +49,10 @@ impl HbFace {
     fn new(font: &FontRef) -> HbFace {
         let data = font.font.copy_font_data().expect("font data unavailable");
         let blob = Blob::new_from_arc_vec(data);
-        unsafe {
-            let hb_face = hb_face_create(blob.as_raw(), 0);
+        
+            let hb_face = unsafe { hb_face_create(blob.as_raw(), 0) };
             HbFace { hb_face }
-        }
+        
     }
 }
 

--- a/src/unicode_funcs.rs
+++ b/src/unicode_funcs.rs
@@ -20,10 +20,10 @@ use crate::tables::{
 };
 
 fn make_unicode_funcs() -> *mut hb_unicode_funcs_t {
-    unsafe {
-        let funcs_ptr = hb_unicode_funcs_create(null_mut());
+    
+        let funcs_ptr = unsafe { hb_unicode_funcs_create(null_mut()) };
         funcs_ptr
-    }
+    
 }
 
 pub fn install_unicode_funcs(buffer: &mut Buffer) {


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
References
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html